### PR TITLE
Fix the animation file issue on binding

### DIFF
--- a/sample/ElottieFormsGallery/ElottieFormsGallery/ElottieFormsGallery.csproj
+++ b/sample/ElottieFormsGallery/ElottieFormsGallery/ElottieFormsGallery.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.3.2" />
-    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
+    <PackageReference Include="Tizen.Wearable.CircularUI" Version="1.5.0" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElottieSharp.Forms/ElottieSharp.Forms.csproj
+++ b/src/ElottieSharp.Forms/ElottieSharp.Forms.csproj
@@ -8,7 +8,7 @@
     <Description>ElottieSharp.Forms is a Lottie animation view for Xamarin.Froms.</Description>
     <PackageLicense>https://www.apache.org/licenses/LICENSE-2.0</PackageLicense>
     <PackageTags>xamarin;forms;tizen;tizen.net;lottie</PackageTags>
-    <projectUrl>>https://github.com/TizenAPI/ElottieSharp</projectUrl>
+    <projectUrl>https://github.com/TizenAPI/ElottieSharp</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/TizenAPI/ElottieSharp/master/assets/images/logo.png</iconUrl>
     <Copyright>© Samsung Electronics Co., Ltd All Rights Reserved</Copyright>
   </PropertyGroup>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.2.0.709249" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
     <Compile Remove="Platforms\**\*.cs" />
     <None Include="Platforms\**\*.cs" />
   </ItemGroup>

--- a/src/ElottieSharp.Forms/Platforms/Tizen/ElottieAnimationViewRenderer.cs
+++ b/src/ElottieSharp.Forms/Platforms/Tizen/ElottieAnimationViewRenderer.cs
@@ -143,6 +143,9 @@ namespace ElottieSharp.Forms.Tizen
 
         void UpdateAnimationFile()
         {
+            if (string.IsNullOrEmpty(Element.AnimationFile))
+                return;
+
             Control.SetAnimation(ResourcePath.GetPath(Element.AnimationFile));
             ElementController.SendAnimationInitialized(new AnimationInitializedEventArgs(Control.TotalFrame, Control.DurationTime, Control.IsPlaying));
             if (Element.AutoPlay)


### PR DESCRIPTION
This PR is to handle the invalid animation file value when the it is not passed through data binding.
- fixes #16 

Plus, update the version of referenced Xamarin.Forms version to 4.6.0.967