### PR TITLE
Fix image size correctly

### DIFF
--- a/sample/ElottieFormsGallery/ElottieFormsGallery.Tizen/ElottieFormsGallery.Tizen.cs
+++ b/sample/ElottieFormsGallery/ElottieFormsGallery.Tizen/ElottieFormsGallery.Tizen.cs
@@ -1,6 +1,6 @@
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
-using Tizen.Wearable.CircularUI.Forms.Renderer;
+using Tizen.Wearable.CircularUI.Forms;
 
 namespace ElottieFormsGallery
 {

--- a/sample/ElottieFormsGallery/ElottieFormsGallery/MainPage.xaml
+++ b/sample/ElottieFormsGallery/ElottieFormsGallery/MainPage.xaml
@@ -15,6 +15,8 @@
                     <e:ElottieAnimationView
                         AnimationFile="{Binding AnimationFile}"
                         AutoRepeat="False"
+                        WidthRequest="360"
+                        HeightRequest="360"
                         HorizontalOptions="FillAndExpand"
                         VerticalOptions="FillAndExpand"/>
                 </StackLayout>

--- a/sample/ElottieSharpGallery/App.cs
+++ b/sample/ElottieSharpGallery/App.cs
@@ -73,6 +73,7 @@ namespace ElottieSharpGallery
                     AutoRepeat = true,
                     MinimumWidth = window.ScreenSize.Width,
                 };
+                _views[i].SetSize(window.ScreenSize);
                 _views[i].Show();
 
                 var path = Path.Combine(DirectoryInfo.Resource, _files[i]);

--- a/sample/ElottieSharpGallery/ElottieSharpGallery.csproj
+++ b/sample/ElottieSharpGallery/ElottieSharpGallery.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
 
   <!-- Property Group for .NET Core Project -->
   <PropertyGroup>
@@ -6,25 +6,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-    <Folder Include="res\" />
-  </ItemGroup>
-
-  <!-- Include Nuget Package for Tizen Project building -->
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.0">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ElottieSharp\ElottieSharp.csproj" />
   </ItemGroup>

--- a/sample/HelloElottieSharp/HelloElottieSharp.cs
+++ b/sample/HelloElottieSharp/HelloElottieSharp.cs
@@ -73,7 +73,7 @@ namespace HelloElottieSharp
             {
                 button.Text = e.CurrentFrame+"";
             };
-            lottie.Size = new Size(500, 500);
+            lottie.SetSize(500, 500);
 
             button.Clicked += (s, e) =>
             {

--- a/sample/HelloElottieSharp/HelloElottieSharp.csproj
+++ b/sample/HelloElottieSharp/HelloElottieSharp.csproj
@@ -1,17 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
   </PropertyGroup>
-  
-  <!-- Include Nuget Package for Tizen Project building -->
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="5.0.0.14562">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\ElottieSharp\ElottieSharp.csproj" />
   </ItemGroup>

--- a/src/ElottieSharp.Forms/Platforms/Tizen/ElottieAnimationViewRenderer.cs
+++ b/src/ElottieSharp.Forms/Platforms/Tizen/ElottieAnimationViewRenderer.cs
@@ -20,6 +20,7 @@ using System;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
 using TForms = Xamarin.Forms.Forms;
+using ESize = ElmSharp.Size;
 
 [assembly: ExportRenderer(typeof(ElottieAnimationView), typeof(ElottieAnimationViewRenderer))]
 namespace ElottieSharp.Forms.Tizen
@@ -73,6 +74,11 @@ namespace ElottieSharp.Forms.Tizen
 
         protected override void OnElementChanged(ElementChangedEventArgs<ElottieAnimationView> e)
         {
+            if (!e.NewElement.IsSet(VisualElement.WidthRequestProperty) || !e.NewElement.IsSet(VisualElement.HeightRequestProperty))
+            {
+                throw new InvalidOperationException("WidthRequest and HeightRequest should be set for rendering animation correctly.");
+            }
+
             if (Control == null)
             {
                 SetNativeControl(new LottieAnimationView(TForms.NativeParent));
@@ -98,7 +104,15 @@ namespace ElottieSharp.Forms.Tizen
                 e.NewElement.PauseRequested += OnPauseRequested;
                 e.NewElement.SeekRequested += OnSeekRequested;
             }
+
             base.OnElementChanged(e);
+        }
+
+        protected override ESize Measure(int availableWidth, int availableHeight)
+        {
+            var size = new ESize(TForms.ConvertToScaledPixel(availableWidth), TForms.ConvertToScaledPixel(availableHeight));
+            Control.SetSize(size);
+            return size;
         }
 
         void UpdateAutoPlay(bool initialize)

--- a/src/ElottieSharp/LottieAnimationView.cs
+++ b/src/ElottieSharp/LottieAnimationView.cs
@@ -175,6 +175,7 @@ namespace ElottieSharp
         /// <summary>
         /// Gets or sets the desired size of animation.
         /// </summary>
+        [Obsolete ("This property is obsolete as of 0.9.7-preview. Prelase use SetSize() instead")]
         public Size Size
         {
             get
@@ -187,6 +188,25 @@ namespace ElottieSharp
             {
                 Interop.Evas.evas_object_image_size_set(RealHandle, value.Width, value.Height);
             }
+        }
+
+        /// <summary>
+        /// Sets the desired size of animation.
+        /// </summary>
+        /// <param name="width">The width of animatoin</param>
+        /// <param name="height">The height of animatoin</param>
+        public void SetSize(int width, int height)
+        {
+            Interop.Evas.evas_object_image_size_set(RealHandle, width, height);
+        }
+
+        /// <summary>
+        /// Sets the desired size of animation.
+        /// </summary>
+        /// <param name="size">The size of animation</param>
+        public void SetSize(Size size)
+        {
+            Interop.Evas.evas_object_image_size_set(RealHandle, size.Width, size.Height);
         }
 
         /// <summary>
@@ -332,8 +352,6 @@ namespace ElottieSharp
             Interop.Evas.evas_object_image_alpha_set(evasImage, true);
             _showed = new EvasObjectEvent(this, evasImage, EvasObjectCallbackType.Show);
             _hid = new EvasObjectEvent(this, evasImage, EvasObjectCallbackType.Hide);
-            //FIXME
-            Interop.Evas.evas_object_image_size_set(evasImage, 360, 360);
             return evasImage;
         }
 
@@ -371,8 +389,10 @@ namespace ElottieSharp
             IntPtr buffer = Interop.Evas.evas_object_image_data_get(RealHandle, true);
             int imageRowStride = Interop.Evas.evas_object_image_stride_get(RealHandle);
 
-            int w = Size.Width;
-            int h = Size.Height;
+            int w;
+            int h;
+            Interop.Evas.evas_object_image_size_get(RealHandle, out w, out h);
+
             NativePlayerDelegator.InvokeAnimationRenderAsync(_animation, CurrentFrame, buffer, w, h, imageRowStride);
             NativePlayerDelegator.InvokeAnimationRenderFlush(_animation);
 


### PR DESCRIPTION
This PR fixes the image size correctly. 

`WidthRequest` and `HeightRequest` properties of `ElottieAnimationView` must be set to render the size of animation correctly.
To prevent misuse, `InvalidOperationException` will be thrown, if you don't set these properties before using it.

### API Changes ###
**```ElottieSharp```**
Added:
 - public void LottieAnimationView.SetSize(int w, int h)
 - public void LottieAnimationView.SetSize(Size size)

Obsolete
- public Size LottieAnimationView.Size {get; set;} // use SetSize() instead.
